### PR TITLE
StateMachine#can_transition? now uses Guard#allowed? instead of Guard…

### DIFF
--- a/lib/end_state/state_machine.rb
+++ b/lib/end_state/state_machine.rb
@@ -14,8 +14,9 @@ module EndState
     end
 
     def can_transition?(end_state, params = {})
+      __sm_reset_messages
       return false unless __sm_transition_configuration_for(state.to_sym, end_state.to_sym)
-      __sm_transition_for(end_state.to_sym).will_allow?(params)
+      __sm_transition_for(end_state.to_sym).allowed?(params)
     end
 
     def transition(end_state, params = {}, mode = self.class.mode)

--- a/lib/end_state/version.rb
+++ b/lib/end_state/version.rb
@@ -1,3 +1,3 @@
 module EndState
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end

--- a/spec/end_state/state_machine_spec.rb
+++ b/spec/end_state/state_machine_spec.rb
@@ -260,6 +260,29 @@ module EndState
           specify { expect(machine.can_transition? :d).to be true }
         end
       end
+
+      context 'when a guard fails' do
+        let(:object) { OpenStruct.new(state: :c) }
+        let(:guard_with_messages) {
+          Class.new(EndState::Guard) do
+            define_method(:will_allow?) do |params={}|
+              false
+            end
+
+            define_method(:failed) do
+              add_error "An error occurred."
+            end
+          end
+        }
+        before :each do
+          StateMachine.transition(c: :d) {|t| t.guard guard_with_messages }
+        end
+
+        it 'executes the failure callback' do
+          machine.can_transition? :d
+          expect(machine.failure_messages).to include("An error occurred.")
+        end
+      end
     end
 
     describe '#transition' do


### PR DESCRIPTION
StateMachine#can_transition? now uses Guard#allowed? instead of Guard#will_allow?

@alexpeachey I could really use `failure_messages` when checking `can_transition?`. Thoughts?