### PR TITLE
Add MissingParams custom error for require_params

### DIFF
--- a/lib/end_state/errors.rb
+++ b/lib/end_state/errors.rb
@@ -1,8 +1,9 @@
 module EndState
-  class Error < StandardError; end
-  class UnknownState < Error; end
-  class InvalidTransition < Error; end
-  class GuardFailed < Error; end
-  class ConcluderFailed < Error; end
-  class EventConflict < Error; end
+  Error = Class.new(StandardError)
+  UnknownState = Class.new(Error)
+  InvalidTransition = Class.new(Error)
+  GuardFailed = Class.new(Error)
+  ConcluderFailed = Class.new(Error)
+  EventConflict = Class.new(Error)
+  MissingParams = Class.new(Error)
 end

--- a/lib/end_state/transition.rb
+++ b/lib/end_state/transition.rb
@@ -18,7 +18,7 @@ module EndState
     end
 
     def allowed?(params={})
-      raise "Missing params: #{missing_params(params).join(',')}" unless missing_params(params).empty?
+      return params_not_provided(missing_params(params)) unless missing_params(params).empty?
       guards.all? { |guard| guard.new(object, state, params).allowed? }
     end
 
@@ -40,6 +40,10 @@ module EndState
 
     def conclude_failed
       failed ConcluderFailed, 'rolled back'
+    end
+
+    def params_not_provided(params_list)
+      fail MissingParams, "Missing params: #{params_list.join(',')}"
     end
 
     def conclude(params={})

--- a/spec/end_state/state_machine_spec.rb
+++ b/spec/end_state/state_machine_spec.rb
@@ -213,7 +213,7 @@ module EndState
         let(:object) { OpenStruct.new(state: :c) }
 
         it 'blocks invalid events' do
-          expect { machine.go! }.to raise_error
+          expect { machine.go! }.to raise_error(InvalidTransition)
           expect(machine.state).to eq :c
         end
       end

--- a/spec/end_state/transition_spec.rb
+++ b/spec/end_state/transition_spec.rb
@@ -33,8 +33,8 @@ module EndState
             before { configuration.required_params = [:foo, :bar] }
 
             context 'and not all required are provided' do
-              it 'throws an exception' do
-                expect { transition.allowed? foo: 'something' }.to raise_error('Missing params: bar')
+              it 'raises MissingParams' do
+                expect { transition.allowed? foo: 'something' }.to raise_error(MissingParams, 'Missing params: bar')
               end
             end
 


### PR DESCRIPTION
This PR is for issue #33.

My goal was to modify the existing style in `Transition` as little as possible, but there's definitely an opportunity to reconstruct the behavior around the `missing_params(params)` method. At the very least, something like a `params_missing?` predicate to replace `missing_params(params).empty?`. I'm open to extending this PR to include that, if we think it's acceptable.

Also, I've moved the error class definitions over to a more directed style, to remove the 1-line `class` statements. The generally accepted _better_ practice is to use `Class.new()` to define a proper named constant that depends from an existing defined class/constant. I also think it reads as much cleaner.